### PR TITLE
common: add kind/epic and kind/subtask labels

### DIFF
--- a/labelsync.yml
+++ b/labelsync.yml
@@ -515,6 +515,16 @@ repos:
         description: Candidate for next Milestone.
         alias: []
         siblings: []
+      kind/subtask:
+        color: '#3B5BDB'
+        description: Subtask that was created from an epic
+        alias: []
+        siblings: []
+      kind/epic:
+        color: '#3B5BDB'
+        description: A high-level initiative that has many subtasks.
+        alias: []
+        siblings: []
       kind/question:
         color: '#3B5BDB'
         description: Developer asked a question. No code changes required.
@@ -650,6 +660,16 @@ repos:
       process/candidate:
         color: '#EB9100'
         description: Candidate for next Milestone.
+        alias: []
+        siblings: []
+      kind/subtask:
+        color: '#3B5BDB'
+        description: Subtask that was created from an epic
+        alias: []
+        siblings: []
+      kind/epic:
+        color: '#3B5BDB'
+        description: A high-level initiative that has many subtasks.
         alias: []
         siblings: []
       kind/question:
@@ -789,6 +809,16 @@ repos:
         description: Candidate for next Milestone.
         alias: []
         siblings: []
+      kind/subtask:
+        color: '#3B5BDB'
+        description: Subtask that was created from an epic
+        alias: []
+        siblings: []
+      kind/epic:
+        color: '#3B5BDB'
+        description: A high-level initiative that has many subtasks.
+        alias: []
+        siblings: []
       kind/question:
         color: '#3B5BDB'
         description: Developer asked a question. No code changes required.
@@ -924,6 +954,16 @@ repos:
       process/candidate:
         color: '#EB9100'
         description: Candidate for next Milestone.
+        alias: []
+        siblings: []
+      kind/subtask:
+        color: '#3B5BDB'
+        description: Subtask that was created from an epic
+        alias: []
+        siblings: []
+      kind/epic:
+        color: '#3B5BDB'
+        description: A high-level initiative that has many subtasks.
         alias: []
         siblings: []
       kind/question:
@@ -1063,6 +1103,16 @@ repos:
         description: Candidate for next Milestone.
         alias: []
         siblings: []
+      kind/subtask:
+        color: '#3B5BDB'
+        description: Subtask that was created from an epic
+        alias: []
+        siblings: []
+      kind/epic:
+        color: '#3B5BDB'
+        description: A high-level initiative that has many subtasks.
+        alias: []
+        siblings: []
       kind/question:
         color: '#3B5BDB'
         description: Developer asked a question. No code changes required.
@@ -1198,6 +1248,16 @@ repos:
       process/candidate:
         color: '#EB9100'
         description: Candidate for next Milestone.
+        alias: []
+        siblings: []
+      kind/subtask:
+        color: '#3B5BDB'
+        description: Subtask that was created from an epic
+        alias: []
+        siblings: []
+      kind/epic:
+        color: '#3B5BDB'
+        description: A high-level initiative that has many subtasks.
         alias: []
         siblings: []
       kind/question:
@@ -1343,6 +1403,16 @@ repos:
         description: Candidate for next Milestone.
         alias: []
         siblings: []
+      kind/subtask:
+        color: '#3B5BDB'
+        description: Subtask that was created from an epic
+        alias: []
+        siblings: []
+      kind/epic:
+        color: '#3B5BDB'
+        description: A high-level initiative that has many subtasks.
+        alias: []
+        siblings: []
       kind/question:
         color: '#3B5BDB'
         description: Developer asked a question. No code changes required.
@@ -1478,6 +1548,16 @@ repos:
       process/candidate:
         color: '#EB9100'
         description: Candidate for next Milestone.
+        alias: []
+        siblings: []
+      kind/subtask:
+        color: '#3B5BDB'
+        description: Subtask that was created from an epic
+        alias: []
+        siblings: []
+      kind/epic:
+        color: '#3B5BDB'
+        description: A high-level initiative that has many subtasks.
         alias: []
         siblings: []
       kind/question:
@@ -1617,6 +1697,16 @@ repos:
         description: Candidate for next Milestone.
         alias: []
         siblings: []
+      kind/subtask:
+        color: '#3B5BDB'
+        description: Subtask that was created from an epic
+        alias: []
+        siblings: []
+      kind/epic:
+        color: '#3B5BDB'
+        description: A high-level initiative that has many subtasks.
+        alias: []
+        siblings: []
       kind/question:
         color: '#3B5BDB'
         description: Developer asked a question. No code changes required.
@@ -1752,6 +1842,16 @@ repos:
       process/candidate:
         color: '#EB9100'
         description: Candidate for next Milestone.
+        alias: []
+        siblings: []
+      kind/subtask:
+        color: '#3B5BDB'
+        description: Subtask that was created from an epic
+        alias: []
+        siblings: []
+      kind/epic:
+        color: '#3B5BDB'
+        description: A high-level initiative that has many subtasks.
         alias: []
         siblings: []
       kind/question:
@@ -1891,6 +1991,16 @@ repos:
         description: Candidate for next Milestone.
         alias: []
         siblings: []
+      kind/subtask:
+        color: '#3B5BDB'
+        description: Subtask that was created from an epic
+        alias: []
+        siblings: []
+      kind/epic:
+        color: '#3B5BDB'
+        description: A high-level initiative that has many subtasks.
+        alias: []
+        siblings: []
       kind/question:
         color: '#3B5BDB'
         description: Developer asked a question. No code changes required.
@@ -2026,6 +2136,16 @@ repos:
       process/candidate:
         color: '#EB9100'
         description: Candidate for next Milestone.
+        alias: []
+        siblings: []
+      kind/subtask:
+        color: '#3B5BDB'
+        description: Subtask that was created from an epic
+        alias: []
+        siblings: []
+      kind/epic:
+        color: '#3B5BDB'
+        description: A high-level initiative that has many subtasks.
         alias: []
         siblings: []
       kind/question:
@@ -2165,6 +2285,16 @@ repos:
         description: Candidate for next Milestone.
         alias: []
         siblings: []
+      kind/subtask:
+        color: '#3B5BDB'
+        description: Subtask that was created from an epic
+        alias: []
+        siblings: []
+      kind/epic:
+        color: '#3B5BDB'
+        description: A high-level initiative that has many subtasks.
+        alias: []
+        siblings: []
       kind/question:
         color: '#3B5BDB'
         description: Developer asked a question. No code changes required.
@@ -2300,6 +2430,16 @@ repos:
       process/candidate:
         color: '#EB9100'
         description: Candidate for next Milestone.
+        alias: []
+        siblings: []
+      kind/subtask:
+        color: '#3B5BDB'
+        description: Subtask that was created from an epic
+        alias: []
+        siblings: []
+      kind/epic:
+        color: '#3B5BDB'
+        description: A high-level initiative that has many subtasks.
         alias: []
         siblings: []
       kind/question:
@@ -2439,6 +2579,16 @@ repos:
         description: Candidate for next Milestone.
         alias: []
         siblings: []
+      kind/subtask:
+        color: '#3B5BDB'
+        description: Subtask that was created from an epic
+        alias: []
+        siblings: []
+      kind/epic:
+        color: '#3B5BDB'
+        description: A high-level initiative that has many subtasks.
+        alias: []
+        siblings: []
       kind/question:
         color: '#3B5BDB'
         description: Developer asked a question. No code changes required.
@@ -2574,6 +2724,16 @@ repos:
       process/candidate:
         color: '#EB9100'
         description: Candidate for next Milestone.
+        alias: []
+        siblings: []
+      kind/subtask:
+        color: '#3B5BDB'
+        description: Subtask that was created from an epic
+        alias: []
+        siblings: []
+      kind/epic:
+        color: '#3B5BDB'
+        description: A high-level initiative that has many subtasks.
         alias: []
         siblings: []
       kind/question:
@@ -2713,6 +2873,16 @@ repos:
         description: Candidate for next Milestone.
         alias: []
         siblings: []
+      kind/subtask:
+        color: '#3B5BDB'
+        description: Subtask that was created from an epic
+        alias: []
+        siblings: []
+      kind/epic:
+        color: '#3B5BDB'
+        description: A high-level initiative that has many subtasks.
+        alias: []
+        siblings: []
       kind/question:
         color: '#3B5BDB'
         description: Developer asked a question. No code changes required.
@@ -2848,6 +3018,16 @@ repos:
       process/candidate:
         color: '#EB9100'
         description: Candidate for next Milestone.
+        alias: []
+        siblings: []
+      kind/subtask:
+        color: '#3B5BDB'
+        description: Subtask that was created from an epic
+        alias: []
+        siblings: []
+      kind/epic:
+        color: '#3B5BDB'
+        description: A high-level initiative that has many subtasks.
         alias: []
         siblings: []
       kind/question:
@@ -2987,6 +3167,16 @@ repos:
         description: Candidate for next Milestone.
         alias: []
         siblings: []
+      kind/subtask:
+        color: '#3B5BDB'
+        description: Subtask that was created from an epic
+        alias: []
+        siblings: []
+      kind/epic:
+        color: '#3B5BDB'
+        description: A high-level initiative that has many subtasks.
+        alias: []
+        siblings: []
       kind/question:
         color: '#3B5BDB'
         description: Developer asked a question. No code changes required.
@@ -3122,6 +3312,16 @@ repos:
       process/candidate:
         color: '#EB9100'
         description: Candidate for next Milestone.
+        alias: []
+        siblings: []
+      kind/subtask:
+        color: '#3B5BDB'
+        description: Subtask that was created from an epic
+        alias: []
+        siblings: []
+      kind/epic:
+        color: '#3B5BDB'
+        description: A high-level initiative that has many subtasks.
         alias: []
         siblings: []
       kind/question:

--- a/src/common/prisma2.ts
+++ b/src/common/prisma2.ts
@@ -41,7 +41,7 @@ export const common: Label[] = [
   label({
     name: 'kind/support',
     color: colors.kind,
-    description: 'Support requests for usage or other areas'
+    description: 'Support requests for usage or other areas',
   }),
   label({
     name: 'kind/regression',
@@ -78,7 +78,16 @@ export const common: Label[] = [
     color: colors.kind,
     description: 'Developer asked a question. No code changes required.',
   }),
-
+  label({
+    name: 'kind/epic',
+    color: colors.kind,
+    description: 'A high-level initiative that has many subtasks.',
+  }),
+  label({
+    name: 'kind/subtask',
+    color: colors.kind,
+    description: 'Subtask that was created from an epic',
+  }),
   label({
     name: 'process/candidate',
     color: colors.process,
@@ -89,13 +98,13 @@ export const common: Label[] = [
     name: 'tech/engines',
     color: colors.tech,
     description: 'Issue for tech Engines.',
-    alias: ["team/engines"],
+    alias: ['team/engines'],
   }),
   label({
     name: 'tech/typescript',
     color: colors.tech,
     description: 'Issue for tech TypeScript.',
-    alias: ["team/typescript"],
+    alias: ['team/typescript'],
   }),
 
   label({
@@ -117,7 +126,7 @@ export const common: Label[] = [
     name: 'team/support-engineering',
     color: colors.team,
     description: 'Issue for team Support Engineering.',
-    alias: ["team/support"],
+    alias: ['team/support'],
   }),
 
   label({
@@ -155,7 +164,7 @@ export const common: Label[] = [
   label({
     name: 'engines/other',
     color: colors.engines,
-    description: 'Issue in the engines repo that does not fit one of the other labels.',
+    description:
+      'Issue in the engines repo that does not fit one of the other labels.',
   }),
-
 ]


### PR DESCRIPTION
This PR adds `kind/epic` and `kind/subtask` labels to all of our repositories.

This will hopefully give us a better way to organize initiatives. I've written up some thoughts on how I see this working: https://www.notion.so/prismaio/Client-Team-Breaking-Down-Issues-Better-5de650acc1164177b2b025ea53a7f3f7